### PR TITLE
Move from direct calls to LF SFDC to using the LF Members endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 *.txt
 __pycache__
 
+*.swp
+
 # add back in for packaging
 !requirements.txt

--- a/LandscapeTools.py
+++ b/LandscapeTools.py
@@ -155,7 +155,6 @@ class Member:
 
 
     def toLandscapeItemAttributes(self):
-        
         allowedKeys = [
             'name',
             'homepage_url',
@@ -227,9 +226,8 @@ class Member:
 #
 class Members(ABC):
 
-    members = []
-
     def __init__(self, loadData = False):
+        self.members = []
         if loadData:
             self.loadData()
 
@@ -288,12 +286,12 @@ class Members(ABC):
 
 class SFDCMembers(Members):
 
-    members = []
     project = 'tlf' # The Linux Foundation
 
     endpointURL = 'https://api-gw.platform.linuxfoundation.org/project-service/v1/public/projects/{}/members' 
 
     def __init__(self, project = None, loadData = True):
+
         if project:
             self.project = project
         super().__init__(loadData)
@@ -320,16 +318,17 @@ class SFDCMembers(Members):
                     member.membership = record['Membership']['Name']
                 except ValueError as e:
                     pass
-                try:
-                    member.logo = record['Logo']
-                except ValueError as e:
-                    pass
-                if record['CrunchBaseURL'] and record['CrunchBaseURL'] != '':
+                if 'Logo' in record:
+                    try:
+                        member.logo = record['Logo']
+                    except ValueError as e:
+                        pass
+                if 'CrunchBaseURL' in record and record['CrunchBaseURL'] != '':
                     try:
                         member.crunchbase = record['CrunchBaseURL']
                     except ValueError as e:
                         pass
-                if record['Twitter'] and record['Twitter'] != '':
+                if 'Twitter' in record and record['Twitter'] != '':
                     try:
                         member.twitter = record['Twitter']
                     except ValueError as e:
@@ -348,7 +347,6 @@ class SFDCMembers(Members):
 
 class LandscapeMembers(Members):
 
-    members = []
     landscapeListYAML = 'https://raw.githubusercontent.com/cncf/landscapeapp/master/landscapes.yml'
     landscapeSettingsYAML = 'https://raw.githubusercontent.com/{repo}/master/settings.yml'
     landscapeLandscapeYAML = 'https://raw.githubusercontent.com/{repo}/master/landscape.yml'
@@ -427,7 +425,6 @@ class LandscapeMembers(Members):
 
 class CrunchbaseAPIMembers(Members):
 
-    members = []
     crunchbaseKey = ''
 
     def loadData(self):
@@ -464,7 +461,6 @@ class CrunchbaseAPIMembers(Members):
 
 class CrunchbaseMembers(Members):
 
-    members = []
     bulkdatafile = 'organizations.csv'
 
     def __init__(self, bulkdatafile = None, loadData = False):

--- a/LandscapeTools.py
+++ b/LandscapeTools.py
@@ -139,6 +139,8 @@ class Member:
 
     @twitter.setter
     def twitter(self, twitter):
+        if not twitter:
+            return
         if not twitter.startswith('https://twitter.com/'):
             # fix the URL if it's not formatted right
             o = urlparse(twitter)
@@ -238,12 +240,13 @@ class Members(ABC):
     def find(self, org, website):
         normalizedorg = self.normalizeCompany(org)
         normalizedwebsite = self.normalizeURL(website)
+        found = []
 
         for member in self.members:
             if ( self.normalizeCompany(member.orgname) == normalizedorg or member.website == website):
-                return member
+                found.append(member)
 
-        return False
+        return found
 
     def normalizeCompany(self, company):
 
@@ -339,11 +342,12 @@ class SFDCMembers(Members):
         normalizedorg = self.normalizeCompany(org)
         normalizedwebsite = self.normalizeURL(website)
 
+        members = []
         for member in self.members:
             if ( self.normalizeCompany(member.orgname) == normalizedorg or member.website == website) and member.membership == membership:
-                return member
+                members.append(member)
 
-        return False
+        return members
 
 class LandscapeMembers(Members):
 
@@ -353,7 +357,7 @@ class LandscapeMembers(Members):
     landscapeLogo = 'https://raw.githubusercontent.com/{repo}/master/hosted_logos/{logo}'
     skipLandscapes = ['openjsf']
 
-    def __init__(self, landscapeListYAML = None, loadData = False):
+    def __init__(self, landscapeListYAML = None, loadData = True):
         if landscapeListYAML:
             self.landscapeListYAML = landscapeListYAML
         super().__init__(loadData)
@@ -411,7 +415,6 @@ class LandscapeMembers(Members):
                                 member.crunchbase = item['crunchbase']
                             except ValueError as e:
                                 pass
-                            
                             self.members.append(member)
 
     def normalizeLogo(self, logo, landscapeRepo):
@@ -438,6 +441,7 @@ class CrunchbaseAPIMembers(Members):
             self.crunchbaseKey = os.getenv('CRUNCHBASE_KEY')
         cb = CrunchBase(self.crunchbaseKey)
 
+        members = []
         for result in cb.organizations(org):
             company = cb.organization(result.permalink)
             if self.normalizeCompany(company.name) == normalizedorg:
@@ -455,9 +459,9 @@ class CrunchbaseAPIMembers(Members):
                 except ValueError as e:
                     pass
 
-                return member
+                members.append(member)
 
-        return False
+        return members
 
 class CrunchbaseMembers(Members):
 

--- a/LandscapeTools.py
+++ b/LandscapeTools.py
@@ -146,7 +146,7 @@ class Member:
             o = urlparse(twitter)
             if o.netloc == '':
                 twitter = "https://twitter.com/{}".format(twitter)
-            if (o.netloc == "twitter.com" or o.netloc == "www.twitter.com"):
+            elif (o.netloc == "twitter.com" or o.netloc == "www.twitter.com"):
                 twitter = "https://twitter.com{path}".format(path=o.path)
             else:
                 self._validTwitter = False

--- a/LandscapeTools.py
+++ b/LandscapeTools.py
@@ -11,7 +11,6 @@ import sys
 import re
 import os
 import os.path
-import json
 import unicodedata
 from os.path import normpath, basename
 from datetime import datetime
@@ -302,8 +301,8 @@ class SFDCMembers(Members):
     def loadData(self):
         print("--Loading SFDC Members data--")
 
-        with urllib.request.urlopen(self.endpointURL.format(self.project)) as projectEndpointUrl:
-            memberList = json.loads(projectEndpointUrl.read().decode())
+        with requests.get(self.endpointURL.format(self.project)) as endpointResponse:
+            memberList = endpointResponse.json()
             for record in memberList:
                 if self.find(record['Name'],record['Website'],record['Membership']['Name']):
                     continue

--- a/LandscapeTools.py
+++ b/LandscapeTools.py
@@ -290,7 +290,7 @@ class SFDCMembers(Members):
 
     project = 'tlf' # The Linux Foundation
 
-    endpointURL = 'https://api-gw.platform.linuxfoundation.org/project-service/v1/public/projects/{}/members' 
+    endpointURL = 'https://api-gw.platform.linuxfoundation.org/project-service/v1/public/projects/{}/members?orderBy=name' 
 
     def __init__(self, project = None, loadData = True):
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@ Current tools are:
 
 ## Installation
 
-```
+```bash
 git clone https://github.com/jmertic/landscape-tools
 cd landscape-tools
 chmod +x *.py
 pip install -r requirements.txt
-./downloadcrunchbasedata.sh
+```
+
+If you wish to use crunchbase as a data source, add this command.
+
+```bash
+./downloadcrunchbasedata.sh 
 ```
 
 ## Configuration
@@ -36,7 +41,7 @@ landscapeMemberClasses: # classes of membership; name matches how it's listed in
      category: Platinum
    - name: Silver Membership
      category: Silver
-project: # SF ID record for the project as listed in LF SFDC
+project: # project slug
 landscapeMemberCategory: # category name of the members section in the landscape.yml file
 landscapefile: # filename to use for the outputted landscape.yml file
 missingcsvfile: # filename to use for the list of entries with missing parts ( such as a logo, website, or crunchbase entry )
@@ -44,7 +49,7 @@ missingcsvfile: # filename to use for the list of entries with missing parts ( s
 
 ### Environment variables
 
-In addition, this depends on `CRUNCHBASE_KEY` being set to a valid key. In addition, `SF_USERNAME`, `SF_PASSWORD`, and `SF_TOKEN` must be set to match your Salesforce credentials ( instructions how to get one at https://help.salesforce.com/articleView?id=user_security_token.htm&type=5)
+This depends on `CRUNCHBASE_KEY` being set to a valid key if you wish to use that as a data source ( required by [downloadcrunchbasedata.sh](downloadcrunchbasedata.sh) ).
 
 ## Contributing
 

--- a/landscapemembers.py
+++ b/landscapemembers.py
@@ -25,12 +25,9 @@ def main():
         config = Config("config.yaml")
 
     # load member data sources
-    sfdcmembers = SFDCMembers(loadData = False, memberClasses = config.landscapeMemberClasses, sf_username = config.sf_username, sf_password = config.sf_password, sf_token = config.sf_token)
-    sfdcmembers.project = config.project
-    sfdcmembers.loadData()
-    cbmembers = CrunchbaseMembers(loadData = False)
-    lsmembers = LandscapeMembers(loadData = False)
-    lsmembers.loadData()
+    sfdcmembers = SFDCMembers(project = config.project)
+    cbmembers = CrunchbaseMembers()
+    lsmembers = LandscapeMembers()
 
     lflandscape = LandscapeOutput()
     lflandscape.landscapeMemberCategory = config.landscapeMemberCategory

--- a/landscapemembers.py
+++ b/landscapemembers.py
@@ -46,16 +46,15 @@ def main():
             landscapeMemberClass = next((item for item in config.landscapeMemberClasses if item["name"] == member.membership), None)
             if ( not landscapeMemberClass is None ) and ( landscapeMemberClass['name'] == member.membership ) and ( memberClass['name'] == landscapeMemberClass['category'] ) :
                 # lookup in other landscapes
-                lookupmember = lsmembers.find(member.orgname, member.website)
-                if lookupmember:
+                for lookupmember in lsmembers.find(member.orgname, member.website):
                     print("...Overlay other landscape data")
                     lookupmember.overlay(member)
                 
                 # overlay crunchbase data
-                cbmember = cbmembers.find(member.orgname,member.website)
-                if (not member.crunchbase and cbmember) or (cbmember and member.crunchbase != cbmember.crunchbase):
-                    print("...Updating crunchbase from Crunchbase")
-                    member.crunchbase = cbmember.crunchbase
+                for cbmember in cbmembers.find(member.orgname,member.website):
+                    if (not member.crunchbase and cbmember) or (cbmember and member.crunchbase != cbmember.crunchbase):
+                        print("...Updating crunchbase from Crunchbase")
+                        member.crunchbase = cbmember.crunchbase
                         
                 # Write out to missing.csv if it's missing key parameters
                 if not member.isValidLandscapeItem():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ beautifulsoup4>=4.8.0
 url-normalize>=1.4.2
 tld>=0.12.2
 pycrunchbase>=0.3.8
+responses>=0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ validators>=0.15.0
 beautifulsoup4>=4.8.0
 url-normalize>=1.4.2
 tld>=0.12.2
-simple-salesforce>=1.1.0
 pycrunchbase>=0.3.8

--- a/tests.py
+++ b/tests.py
@@ -220,6 +220,26 @@ class TestMembers(unittest.TestCase):
         self.assertFalse(members.find('dog','https://bar.com'))
 
     @patch("LandscapeTools.Members.__abstractmethods__", set())
+    def testFindMultiple(self):
+        members = Members()
+        
+        member = Member()
+        member.orgname = 'test'
+        member.website = 'https://foo.com'
+        member.logo = 'Gold.svg'
+        member.crunchbase = 'https://www.crunchbase.com/organization/visual-effects-society'
+        members.members.append(member)
+
+        member = Member()
+        member.orgname = 'test'
+        member.website = 'https://foo.com'
+        member.logo = 'Gold.svg'
+        member.crunchbase = 'https://www.crunchbase.com/organization/visual-effects-society'
+        members.members.append(member)
+        
+        self.assertEquals(len(members.find(member.orgname,member.website)),2)
+    
+    @patch("LandscapeTools.Members.__abstractmethods__", set())
     def testNormalizeCompanyEmptyOrg(self):
         members = Members(loadData=False)
         self.assertEqual(members.normalizeCompany(None),'')
@@ -303,14 +323,14 @@ class TestSFDCMembers(unittest.TestCase):
 class TestLandscapeMembers(unittest.TestCase):
 
     def testNormalizeLogo(self):
-        members = LandscapeMembers()
+        members = LandscapeMembers(loadData = False)
         self.assertEqual(
             'https://raw.githubusercontent.com/dog/cat/master/hosted_logos/mouse.svg',
             members.normalizeLogo('mouse.svg','dog/cat')
         )
 
     def testNormalizeLogoIsEmpty(self):
-        members = LandscapeMembers()
+        members = LandscapeMembers(loadData = False)
         self.assertEqual(
             '',
             members.normalizeLogo('','dog/cat')
@@ -321,7 +341,7 @@ class TestLandscapeMembers(unittest.TestCase):
         )
 
     def testNormalizeLogoIsURL(self):
-        members = LandscapeMembers()
+        members = LandscapeMembers(loadData = False)
         self.assertEqual(
             'https://foo.com/mouse.svg',
             members.normalizeLogo('https://foo.com/mouse.svg','dog/cat')

--- a/tests.py
+++ b/tests.py
@@ -246,7 +246,7 @@ class TestSFDCMembers(unittest.TestCase):
         member.membership = 'Gold'
         member.crunchbase = 'https://www.crunchbase.com/organization/visual-effects-society'
 
-        members = SFDCMembers()
+        members = SFDCMembers(loadData=False)
         members.members.append(member)
 
         self.assertTrue(members.find(member.orgname,member.website,member.membership))
@@ -261,7 +261,7 @@ class TestSFDCMembers(unittest.TestCase):
         member.membership = 'Gold'
         member.crunchbase = 'https://www.crunchbase.com/organization/visual-effects-society'
 
-        members = SFDCMembers()
+        members = SFDCMembers(loadData=False)
         members.members.append(member)
 
         self.assertFalse(members.find('dog','https://bar.com',member.membership))

--- a/tests.py
+++ b/tests.py
@@ -288,6 +288,16 @@ class TestSFDCMembers(unittest.TestCase):
         self.assertEqual(members.members[1].website,"https://hitachi-systems.com/")
         self.assertIsNone(members.members[1].twitter)
 
+    @patch('urllib.request.urlopen')
+    def testLoadDataDuplicates(self,mock_urlopen):
+        mock = MagicMock()
+        mock.getcode.return_value = 200
+        mock.read.return_value = '[{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te04HAAR","Name":"Hitachi, Ltd.","CNCFLevel":"","LinkedInURL":"www.linkedin.com/company/hitachi-data-systems","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/hitachi-ltd.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"hitachi-systems.com"}]'.encode()
+        mock.__enter__.return_value = mock
+        mock_urlopen.return_value = mock
+
+        members = SFDCMembers()
+        self.assertEqual(len(members.members),2)
 
 
 class TestLandscapeMembers(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -343,13 +343,14 @@ class TestSFDCMembers(unittest.TestCase):
         self.assertFalse(members.find('dog','https://bar.com',member.membership))
         self.assertFalse(members.find(member.orgname,member.website,'Silver'))
 
-    @patch('urllib.request.urlopen')
-    def testLoadData(self,mock_urlopen):
-        mock = MagicMock()
-        mock.getcode.return_value = 200
-        mock.read.return_value = '[{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te04HAAR","Name":"Hitachi, Ltd.","CNCFLevel":"","LinkedInURL":"www.linkedin.com/company/hitachi-data-systems","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/hitachi-ltd.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"hitachi-systems.com"}]'.encode()
-        mock.__enter__.return_value = mock
-        mock_urlopen.return_value = mock
+    @responses.activate
+    def testLoadData(self):
+        members = SFDCMembers(loadData = False)
+        responses.add(
+            method=responses.GET,
+            url=members.endpointURL.format(members.project),
+            body="""[{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te04HAAR","Name":"Hitachi, Ltd.","CNCFLevel":"","LinkedInURL":"www.linkedin.com/company/hitachi-data-systems","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/hitachi-ltd.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"hitachi-systems.com"}]"""
+            )
 
         members = SFDCMembers()
         self.assertEqual(members.members[0].orgname,"ConsenSys AG")
@@ -365,13 +366,14 @@ class TestSFDCMembers(unittest.TestCase):
         self.assertEqual(members.members[1].website,"https://hitachi-systems.com/")
         self.assertIsNone(members.members[1].twitter)
 
-    @patch('urllib.request.urlopen')
-    def testLoadDataDuplicates(self,mock_urlopen):
-        mock = MagicMock()
-        mock.getcode.return_value = 200
-        mock.read.return_value = '[{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te04HAAR","Name":"Hitachi, Ltd.","CNCFLevel":"","LinkedInURL":"www.linkedin.com/company/hitachi-data-systems","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/hitachi-ltd.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"hitachi-systems.com"}]'.encode()
-        mock.__enter__.return_value = mock
-        mock_urlopen.return_value = mock
+    @responses.activate
+    def testLoadDataDuplicates(self):
+        members = SFDCMembers(loadData = False)
+        responses.add(
+            url=members.endpointURL.format(members.project),
+            method=responses.GET,
+            body="""[{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te1TUAAZ","Name":"ConsenSys AG","CNCFLevel":"","CrunchBaseURL":"https://crunchbase.com/organization/consensus-systems--consensys-","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/consensys_ag.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"consensys.net"},{"ID":"0014100000Te04HAAR","Name":"Hitachi, Ltd.","CNCFLevel":"","LinkedInURL":"www.linkedin.com/company/hitachi-data-systems","Logo":"https://lf-master-organization-logos-prod.s3.us-east-2.amazonaws.com/hitachi-ltd.svg","Membership":{"Family":"Membership","ID":"01t41000002735aAAA","Name":"Premier Membership","Status":"Active"},"Slug":"hyp","StockTicker":"","Twitter":"","Website":"hitachi-systems.com"}]"""
+            )
 
         members = SFDCMembers()
         self.assertEqual(len(members.members),2)


### PR DESCRIPTION
Also cleans up...

- Members objects sharing data
- Field validation for Twitter type
- Members.find() can now return multiple objects

Signed-off-by: John Mertic <jmertic@linuxfoundation.org>