### PR TITLE
Cleanup work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,9 @@ __pycache__
 
 *.swp
 
+bin/
+lib/
+pyvenv.cfg
+
 # add back in for packaging
 !requirements.txt

--- a/landscape_tools/config.py
+++ b/landscape_tools/config.py
@@ -14,9 +14,15 @@ import ruamel.yaml
 
 class Config:
 
-    project = 'tlf' # The Linux Foundation
+    project = ''
+    landscapeMemberCategory = 'Members'
+    landscapeMemberClasses = [
+        {"name": "Premier Membership", "category": "Premier"},
+        {"name": "General Membership", "category": "General"},
+    ]
     landscapefile = 'landscape.yml'
     missingcsvfile = 'missing.csv'
+    hostedLogosDir = 'hosted_logos'
     memberSuffix = None
 
     def __init__(self, config_file):
@@ -29,6 +35,8 @@ class Config:
 
             if 'project' in data_loaded:
                 self.project = data_loaded['project']
+            else:
+                sys.exit("'project' not defined in config file")
             if 'landscapeMemberCategory' in data_loaded:
                 self.landscapeMemberCategory = data_loaded['landscapeMemberCategory']
             if 'landscapeMemberClasses' in data_loaded:
@@ -37,7 +45,7 @@ class Config:
                 self.landscapefile = data_loaded['landscapefile']
             if 'missingcsvfile' in data_loaded:
                 self.missingcsvfile = data_loaded['missingcsvfile']
-            if 'landscapeName' in data_loaded:
-                self.landscapeName = data_loaded['landscapeName']
             if 'memberSuffix' in data_loaded:
                 self.memberSuffix = data_loaded['memberSuffix']
+            if 'hostedLogosDir' in data_loaded:
+                self.hostedLogosDir = data_loaded['hostedLogosDir']

--- a/landscape_tools/landscapemembers.py
+++ b/landscape_tools/landscapemembers.py
@@ -29,7 +29,7 @@ class LandscapeMembers(Members):
         print("--Loading other landscape members data--")
 
         response = requests.get(self.landscapeListYAML)
-        landscapeList = ruamel.yaml.YAML(typ='unsafe', pure=True).load(response.content)
+        landscapeList = ruamel.yaml.YAML().load(response.content)
 
         for landscape in landscapeList['landscapes']:
             if landscape['name'] in self.skipLandscapes:
@@ -40,7 +40,7 @@ class LandscapeMembers(Members):
             # first figure out where memberships live
             response = requests.get(self.landscapeSettingsYAML.format(repo=landscape['repo']))
             try:
-                settingsYaml = ruamel.yaml.YAML(typ='unsafe', pure=True).load(response.content) 
+                settingsYaml = ruamel.yaml.YAML().load(response.content) 
             except:
                 # skip if the yaml file cannot be loaded
                 continue
@@ -52,7 +52,7 @@ class LandscapeMembers(Members):
             # then load in members only
             response = requests.get(self.landscapeLandscapeYAML.format(repo=landscape['repo']))
             try:
-                landscapeYaml = ruamel.yaml.YAML(typ='unsafe', pure=True).load(response.content)
+                landscapeYaml = ruamel.yaml.YAML().load(response.content)
             except:
                 continue
             for category in landscapeYaml['landscape']:

--- a/landscape_tools/landscapeoutput.py
+++ b/landscape_tools/landscapeoutput.py
@@ -67,7 +67,7 @@ class LandscapeOutput:
 
     def loadLandscape(self, reset=False):
         with open(self.landscapefile, 'r', encoding="utf8", errors='ignore') as fileobject: 
-            self.landscape = ruamel.yaml.YAML(typ='unsafe', pure=True).load(fileobject)
+            self.landscape = ruamel.yaml.YAML().load(fileobject)
             if not self.landscape or not self.landscape['landscape']:
                 self.newLandscape()
             else:

--- a/landscape_tools/landscapeoutput.py
+++ b/landscape_tools/landscapeoutput.py
@@ -141,7 +141,7 @@ class LandscapeOutput:
             os.remove(os.path.normpath(self.hostedLogosDir+"/"+logo))
 
     def _removeNulls(self,yamlout):
-        dump = re.sub('/(- \w+:) null/g', '$1', yamlout)
+        dump = re.sub(r'/(- \w+:) null/g', '$1', yamlout)
         
         return dump
 

--- a/landscape_tools/lfxmembers.py
+++ b/landscape_tools/lfxmembers.py
@@ -57,11 +57,6 @@ class LFXMembers(Members):
                         member.crunchbase = record['CrunchBaseURL']
                     except ValueError as e:
                         pass
-                if 'Twitter' in record and record['Twitter'] != '':
-                    try:
-                        member.twitter = record['Twitter']
-                    except ValueError as e:
-                        pass
                 self.members.append(member)
 
     def find(self, org, website, membership):

--- a/landscapemembers.py
+++ b/landscapemembers.py
@@ -26,6 +26,8 @@ def main():
     args = parser.parse_args()
     if args.configfile:
         config = Config(args.configfile)
+    elif os.path.isfile("config.yml"):
+        config = Config("config.yml")
     else:
         config = Config("config.yaml")
 
@@ -39,6 +41,7 @@ def main():
     lflandscape.landscapeMemberClasses = config.landscapeMemberClasses
     lflandscape.landscapefile = config.landscapefile
     lflandscape.missingcsvfile = config.missingcsvfile
+    lflandscape.hostedLogosDir = config.hostedLogosDir
     if path.exists(config.landscapefile):
         lflandscape.loadLandscape(reset=True)
     else:

--- a/tests.py
+++ b/tests.py
@@ -25,7 +25,7 @@ class TestConfig(unittest.TestCase):
 
     def testLoadConfig(self):
         testconfigfilecontents = """
-landscapeName: aswf
+hostedLogosDir: 'hosted_logos'
 landscapeMemberClasses:
    - name: Premier Membership
      category: Premier
@@ -47,9 +47,31 @@ memberSuffix: " (help)"
         self.assertEqual(config.landscapeMemberCategory,"ASWF Member Company")
         self.assertEqual(config.landscapefile,"landscape.yml")
         self.assertEqual(config.missingcsvfile,"missing.csv")
-        self.assertEqual(config.landscapeName,"aswf")
         self.assertEqual(config.landscapeMemberClasses[0]['name'],"Premier Membership")
         self.assertEqual(config.memberSuffix," (help)")
+
+        os.unlink(tmpfilename.name)
+
+    def testLoadConfigDefaults(self):
+        testconfigfilecontents = """
+project: a09410000182dD2AAI # Academy Software Foundation
+"""
+        tmpfilename = tempfile.NamedTemporaryFile(mode='w',delete=False)
+        tmpfilename.write(testconfigfilecontents)
+        tmpfilename.close()
+
+        config = Config(tmpfilename.name)
+
+        self.assertEqual(config.landscapeMemberCategory,'Members')
+        self.assertEqual(config.landscapeMemberClasses,[
+            {"name": "Premier Membership", "category": "Premier"},
+            {"name": "General Membership", "category": "General"},
+        ])
+        self.assertEqual(config.landscapefile,'landscape.yml')
+        self.assertEqual(config.missingcsvfile,'missing.csv')
+        self.assertEqual(config.hostedLogosDir,'hosted_logos')
+        self.assertIsNone(config.memberSuffix)
+        self.assertEqual(config.project,"a09410000182dD2AAI")
 
         os.unlink(tmpfilename.name)
 

--- a/tests.py
+++ b/tests.py
@@ -75,6 +75,20 @@ project: a09410000182dD2AAI # Academy Software Foundation
 
         os.unlink(tmpfilename.name)
 
+    def testLoadConfigDefaultsNotSet(self):
+        testconfigfilecontents = """
+projectewew: a09410000182dD2AAI # Academy Software Foundation
+"""
+        tmpfilename = tempfile.NamedTemporaryFile(mode='w',delete=False)
+        tmpfilename.write(testconfigfilecontents)
+        tmpfilename.close()
+
+        with self.assertRaises(SystemExit):
+            config = Config(tmpfilename.name)
+
+        os.unlink(tmpfilename.name)
+
+
 class TestMember(unittest.TestCase):
 
     def testSetCrunchbaseValid(self):


### PR DESCRIPTION
A few things...

- Add config option 'hostedLogosDir'.
- Remove config option 'landscapeName', which was never used.
- Set default values for 'landscapeMemberCategory' and 'landscapeMemberClasses'
- Support config.yml in addition to config.yaml
- Throw an error if 'project' is not set in config file.
- Removed the deprecation warnings for ruamel.yaml.